### PR TITLE
Initialize HookExternalId with empty String

### DIFF
--- a/src/Terramar/Packages/Helper/SyncHelper.php
+++ b/src/Terramar/Packages/Helper/SyncHelper.php
@@ -42,6 +42,7 @@ class SyncHelper
                 $package->setFqn($project['path_with_namespace']);
                 $package->setWebUrl($project['web_url']);
                 $package->setSshUrl($project['ssh_url_to_repo']);
+                $package->setHookExternalId('');
                 $package->setConfiguration($configuration);
                 
                 $packages[] = $package;


### PR DESCRIPTION
... because the db constraint is NOT NULL.
