### PR TITLE
Changed GitLab adapter to retrieve only the accessible projects

### DIFF
--- a/src/Plugin/GitLab/SyncAdapter.php
+++ b/src/Plugin/GitLab/SyncAdapter.php
@@ -159,7 +159,7 @@ class SyncAdapter implements SyncAdapterInterface
         $projects = array();
         $page = 1;
         while (true) {
-            $projects = array_merge($projects, $client->api('projects')->all($page, 100));
+            $projects = array_merge($projects, $client->api('projects')->accessible($page, 100));
             $linkHeader = $client->getHttpClient()->getLastResponse()->getHeader('Link');
             if (strpos($linkHeader, 'rel="next"') === false) {
                 break;


### PR DESCRIPTION
The reasoning behind this change is that making the adapter to retrieve
"all" projects would require the API user to have administration access
level, while getting just the accessible project would enable the users
of Packages to create an user with a more controlled set of permissions
(ie: "Reporter" permission on a group or individual repositories).