### PR TITLE
Added FQN Prefix support for GitHub and GitLab plugins.

### DIFF
--- a/src/Plugin/GitHub/Controller.php
+++ b/src/Plugin/GitHub/Controller.php
@@ -31,6 +31,7 @@ class Controller
         $entityManager = $app->get('doctrine.orm.entity_manager');
         $config = new RemoteConfiguration();
         $config->setRemote($remote);
+        $config->setFqnPrefix($request->get('fqn_prefix'));
         $config->setToken($request->get('github_token'));
         $config->setUsername($request->get('github_username'));
         $config->setEnabled($remote->isEnabled());
@@ -65,6 +66,7 @@ class Controller
             return new Response();
         }
 
+        $config->setFqnPrefix($request->get('fqn_prefix'));
         $config->setToken($request->get('github_token'));
         $config->setUsername($request->get('github_username'));
         $config->setEnabled($config->getRemote()->isEnabled());

--- a/src/Plugin/GitHub/RemoteConfiguration.php
+++ b/src/Plugin/GitHub/RemoteConfiguration.php
@@ -48,6 +48,11 @@ class RemoteConfiguration
     private $remote;
 
     /**
+     * @ORM\Column(name="fqn_prefix", type="string", nullable=true)
+     */
+    private $fqn_prefix;
+
+    /**
      * @param mixed $enabled
      */
     public function setEnabled($enabled)
@@ -117,5 +122,21 @@ class RemoteConfiguration
     public function setToken($token)
     {
         $this->token = (string) $token;
+    }
+    
+    /**
+     * @return mixed
+     */
+    public function getFqnPrefix()
+    {
+        return $this->fqn_prefix;
+    }
+
+    /**
+     * @param mixed $prefix
+     */
+    public function setFqnPrefix($prefix)
+    {
+        $this->fqn_prefix = (string) $prefix;
     }
 }

--- a/src/Plugin/GitHub/SyncAdapter.php
+++ b/src/Plugin/GitHub/SyncAdapter.php
@@ -62,6 +62,8 @@ class SyncAdapter implements SyncAdapterInterface
 
         $projects = $this->getAllProjects($remote);
 
+        $config = $this->getApplication()->getConfiguration();
+
         $packages = array();
         foreach ($projects as $project) {
             if (!$this->packageExists($existingPackages, $project['id'])) {
@@ -69,7 +71,7 @@ class SyncAdapter implements SyncAdapterInterface
                 $package->setExternalId($project['id']);
                 $package->setName($project['name']);
                 $package->setDescription($project['description']);
-                $package->setFqn($project['full_name']);
+                $package->setFqn($config->getFqnPrefix() . $project['full_name']);
                 $package->setWebUrl($project['clone_url']);
                 $package->setSshUrl($project['ssh_url']);
                 $package->setHookExternalId('');

--- a/src/Plugin/GitLab/Controller.php
+++ b/src/Plugin/GitLab/Controller.php
@@ -31,6 +31,7 @@ class Controller
         $entityManager = $app->get('doctrine.orm.entity_manager');
         $config = new RemoteConfiguration();
         $config->setRemote($remote);
+        $config->setFqnPrefix($request->get('fqn_prefix'));
         $config->setToken($request->get('gitlab_token'));
         $config->setUrl($request->get('gitlab_url'));
         $config->setEnabled($remote->isEnabled());
@@ -65,6 +66,7 @@ class Controller
             return new Response();
         }
 
+        $config->setFqnPrefix($request->get('gitlab_token'));
         $config->setToken($request->get('gitlab_token'));
         $config->setUrl($request->get('gitlab_url'));
         $config->setEnabled($config->getRemote()->isEnabled());

--- a/src/Plugin/GitLab/RemoteConfiguration.php
+++ b/src/Plugin/GitLab/RemoteConfiguration.php
@@ -48,6 +48,11 @@ class RemoteConfiguration
     private $remote;
 
     /**
+     * @ORM\Column(name="fqn_prefix", type="string", nullable=true)
+     */
+    private $fqn_prefix;
+
+    /**
      * @param mixed $enabled
      */
     public function setEnabled($enabled)
@@ -117,5 +122,21 @@ class RemoteConfiguration
     public function setToken($token)
     {
         $this->token = (string) $token;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getFqnPrefix()
+    {
+        return $this->fqn_prefix;
+    }
+
+    /**
+     * @param mixed $prefix
+     */
+    public function setFqnPrefix($prefix)
+    {
+        $this->fqn_prefix = (string) $prefix;
     }
 }

--- a/src/Plugin/GitLab/SyncAdapter.php
+++ b/src/Plugin/GitLab/SyncAdapter.php
@@ -62,6 +62,8 @@ class SyncAdapter implements SyncAdapterInterface
 
         $projects = $this->getAllProjects($remote);
 
+        $config = $this->getApplication()->getConfiguration();
+
         $packages = array();
         foreach ($projects as $project) {
             if (!$this->packageExists($existingPackages, $project['id'])) {
@@ -69,7 +71,7 @@ class SyncAdapter implements SyncAdapterInterface
                 $package->setExternalId($project['id']);
                 $package->setName($project['name']);
                 $package->setDescription($project['description']);
-                $package->setFqn($project['path_with_namespace']);
+                $package->setFqn($config->getFqnPrefix() . $project['path_with_namespace']);
                 $package->setWebUrl($project['web_url']);
                 $package->setSshUrl($project['ssh_url_to_repo']);
                 $package->setHookExternalId('');

--- a/views/Plugin/GitHub/edit.html.twig
+++ b/views/Plugin/GitHub/edit.html.twig
@@ -16,6 +16,10 @@
     <label for="token">Token</label>
     <input type="text" name="github_token" value="{{ config.token }}" placeholder="Enter Auth Token" id="github_token" class="form-control" required>
   </div>
+  <div class="form-group">
+    <label for="token">FQN Prefix</label>
+    <input type="text" name="fqn_prefix" value="{{ config.fqn_prefix }}" placeholder="Enter FQN Prefix" id="fqn_prefix" class="form-control" required>
+  </div>
 {% endblock %}
 
 {% block javascripts %}

--- a/views/Plugin/GitHub/new.html.twig
+++ b/views/Plugin/GitHub/new.html.twig
@@ -16,6 +16,10 @@
     <label for="token">Token</label>
     <input type="text" name="github_token" placeholder="Enter Auth Token" id="github_token" class="form-control" required>
   </div>
+  <div class="form-group">
+    <label for="token">FQN Prefix</label>
+    <input type="text" name="fqn_prefix" placeholder="Enter FQN Prefix" id="fqn_prefix" class="form-control" required>
+  </div>
 {% endblock %}
 
 {% block javascripts %}

--- a/views/Plugin/GitLab/edit.html.twig
+++ b/views/Plugin/GitLab/edit.html.twig
@@ -16,6 +16,10 @@
     <label for="token">Token</label>
     <input type="text" name="gitlab_token" value="{{ config.token }}" placeholder="Enter Auth Token" id="gitlab_token" class="form-control" required>
   </div>
+  <div class="form-group">
+    <label for="token">FQN Prefix</label>
+    <input type="text" name="fqn_prefix" value="{{ config.fqn_prefix }}" placeholder="Enter FQN Prefix" id="fqn_prefix" class="form-control">
+  </div>
 {% endblock %}
 
 {% block javascripts %}

--- a/views/Plugin/GitLab/new.html.twig
+++ b/views/Plugin/GitLab/new.html.twig
@@ -16,6 +16,10 @@
     <label for="token">Token</label>
     <input type="text" name="gitlab_token" placeholder="Enter Auth Token" id="gitlab_token" class="form-control" required>
   </div>
+  <div class="form-group">
+    <label for="token">FQN Prefix</label>
+    <input type="text" name="fqn_prefix" placeholder="Enter FQN Prefix" id="fqn_prefix" class="form-control">
+  </div>
 {% endblock %}
 
 {% block javascripts %}


### PR DESCRIPTION
This allows a user to set a prefix that will be applied to the package name. This is useful for minimizing namespace clashes.

My reasoning behind implementing these changes is simple: I am working with an already existing namespace structure in our internal GitLab. We have some very generic group names (such as `clients`). This allows us to prefix the group name with a string (such as `lemdig-`).

`clients/codecave` becomes `lemdig-clients/codecave`.
