### PR TITLE
Skip errors when running updateAndBuild through webhooks

### DIFF
--- a/src/Plugin/Satis/Command/UpdateCommand.php
+++ b/src/Plugin/Satis/Command/UpdateCommand.php
@@ -23,6 +23,7 @@ class UpdateCommand extends ContainerAwareCommand
             ->setDefinition(array(
                 new InputArgument('scan-dir', InputArgument::OPTIONAL, 'Directory to look for git repositories'),
                 new InputOption('build', 'b', InputOption::VALUE_NONE, 'Build packages.json after update'),
+                new InputOption('skip-errors', null, InputOption::VALUE_NONE, 'Skip Download or Archive errors'),
             ));
     }
 
@@ -34,6 +35,7 @@ class UpdateCommand extends ContainerAwareCommand
     {
         $configHelper = $this->container->get('packages.plugin.satis.config_helper');
         $configFile = $configHelper->generateConfiguration();
+        $skipErrors = (bool) $input->getOption('skip-errors');
 
         $data = json_decode(file_get_contents($configFile), true);
 
@@ -51,8 +53,7 @@ class UpdateCommand extends ContainerAwareCommand
 
         if ($input->getOption('build')) {
             $command = $this->getApplication()->find('satis:build');
-
-            $input = new ArrayInput(array($configFile));
+            $input = new ArrayInput(['file' => $configFile, '--skip-errors' => $skipErrors]);
             $command->run($input, $output);
         }
     }

--- a/src/Plugin/Satis/UpdateAndBuildJob.php
+++ b/src/Plugin/Satis/UpdateAndBuildJob.php
@@ -18,7 +18,7 @@ class UpdateAndBuildJob extends ContainerAwareJob
     public function run($args)
     {
         $finder = new PhpExecutableFinder();
-        $builder = new ProcessBuilder(array('bin/console', 'satis:update', '--build'));
+        $builder = new ProcessBuilder(array('bin/console', 'satis:update', '--build', '--skip-errors'));
         $builder->setEnv('HOME', $this->getContainer()->getParameter('app.root_dir'));
         $builder->setPrefix($finder->find());
 


### PR DESCRIPTION
When the UI is managed in the team and a repository gets added without composer.json, the webhooks stop functioning. This allows the webhooks to keep updating, even if there are repositories enabled that have no composer.json