### PR TITLE
Fix resque:queue:clear and :list commands by loading config

### DIFF
--- a/src/Console/Command/Queue/ClearCommand.php
+++ b/src/Console/Command/Queue/ClearCommand.php
@@ -13,6 +13,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Terramar\Packages\Console\Command\ContainerAwareCommand;
+use Terramar\Packages\Helper\ResqueHelper;
 
 class ClearCommand extends ContainerAwareCommand
 {
@@ -25,6 +26,8 @@ class ClearCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        ResqueHelper::autoConfigure($this->container);
+
         /** @var \Terramar\Packages\Helper\ResqueHelper $helper */
         $helper = $this->container->get('packages.helper.resque');
         $queue = $input->getArgument('queue');

--- a/src/Console/Command/Queue/ListCommand.php
+++ b/src/Console/Command/Queue/ListCommand.php
@@ -13,6 +13,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Terramar\Packages\Console\Command\ContainerAwareCommand;
+use Terramar\Packages\Helper\ResqueHelper;
 
 class ListCommand extends ContainerAwareCommand
 {
@@ -25,6 +26,8 @@ class ListCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        ResqueHelper::autoConfigure($this->container);
+
         /** @var \Terramar\Packages\Helper\ResqueHelper $helper */
         $helper = $this->container->get('packages.helper.resque');
         $queue = $input->getArgument('queue');

--- a/src/Console/Command/Worker/ListCommand.php
+++ b/src/Console/Command/Worker/ListCommand.php
@@ -26,7 +26,7 @@ class ListCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-		ResqueHelper::autoConfigure($this->container);
+        ResqueHelper::autoConfigure($this->container);
 
         $workers = \Resque_Worker::all();
 

--- a/src/Console/Command/Worker/StopCommand.php
+++ b/src/Console/Command/Worker/StopCommand.php
@@ -29,7 +29,7 @@ class StopCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-		ResqueHelper::autoConfigure($this->container);
+        ResqueHelper::autoConfigure($this->container);
 
         if ($input->getOption('all')) {
             $workers = \Resque_Worker::all();


### PR DESCRIPTION
Neither ClearCommand.php nor ListCommand.php executed ResqueHelper::autoConfigure() which caused them to ignore any Redis configuration set in config.yml.

This fix makes sure that the helper is configured before a connection to Redis is attempted by the resque:queue:clear or resque:queue:list commands.