### PR TITLE
Fix error from Remote when enabling or disabling a Package

### DIFF
--- a/src/Controller/PackageController.php
+++ b/src/Controller/PackageController.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Terramar\Packages\Entity\Package;
 use Terramar\Packages\Event\PackageEvent;
 use Terramar\Packages\Events;
 use Terramar\Packages\Plugin\Actions;
@@ -38,8 +39,9 @@ class PackageController
 
     public function editAction(Application $app, $id)
     {
-        /** @var \Doctrine\ORM\EntityManager $entityManager */
+        /** @var EntityManager $entityManager */
         $entityManager = $app->get('doctrine.orm.entity_manager');
+        /** @var Package $package */
         $package = $entityManager->getRepository('Terramar\Packages\Entity\Package')->find($id);
         if (!$package) {
             throw new NotFoundHttpException('Unable to locate Package');
@@ -47,14 +49,15 @@ class PackageController
 
         return new Response($app->get('templating')->render('Package/edit.html.twig', array(
                 'package' => $package,
-                'remotes' => $this->getRemotes($app->get('doctrine.orm.entity_manager')),
+                'remotes' => $this->getRemotes($entityManager),
             )));
     }
 
     public function updateAction(Application $app, Request $request, $id)
     {
-        /** @var \Doctrine\ORM\EntityManager $entityManager */
+        /** @var EntityManager $entityManager */
         $entityManager = $app->get('doctrine.orm.entity_manager');
+        /** @var Package $package */
         $package = $entityManager->getRepository('Terramar\Packages\Entity\Package')->find($id);
         if (!$package) {
             throw new NotFoundHttpException('Unable to locate Package');

--- a/views/Package/edit.html.twig
+++ b/views/Package/edit.html.twig
@@ -27,6 +27,12 @@
                         <input type="checkbox" name="enabled" value="1" {% if package.enabled %}checked="checked" {% endif %}id="enabled"> &nbsp; Enabled
                     </label>
                 </div>
+                {% if package.enabled and package.hookExternalId is empty %}
+                <div id="package_error" class="callout callout-danger">
+                    The Package is enabled, but no webhook is installed on the Remote.<br>
+                    <strong>Pushing code will not trigger updates within this application.</strong>
+                </div>
+                {% endif %}
                 <div class="form-group">
                     <label for="fqn">Fully-qualified Name</label>
                     <input type="text" name="fqn" value="{{ package.fqn }}" id="fqn" class="form-control" disabled>


### PR DESCRIPTION
This PR fixes #26 and now shows a message on the Package edit page when the Remote webhook is not installed.