### PR TITLE
Add http basic auth to satis-generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,5 @@
 /config.yml
 /cache/*
 /logs/*
-/config/deploy.rb
+/satis/*
 /database.sqlite

--- a/config.yml.dist
+++ b/config.yml.dist
@@ -31,10 +31,14 @@ packages:
   contact_email: 'contact@terramarlabs.com'
 
   # Needs to be set to generate a dist archive
-  base_path:   'https://localhost'
+  base_path:     'https://localhost'
 
   # If set, will place a copy of every tagged package version in the web/dist folder
-  archive:    true
+  archive:       true
+
+  # If set, username and password will be required when attempting to access
+  # Satis-generated files.
+  secure_satis:  false
 
   resque:
     # Redis server host.

--- a/src/DependencyInjection/PackagesConfiguration.php
+++ b/src/DependencyInjection/PackagesConfiguration.php
@@ -26,22 +26,22 @@ class PackagesConfiguration implements ConfigurationInterface
 
         $rootNode
             ->children()
-            ->scalarNode('site_name')->defaultValue('Private Composer Repository')->end()
-            ->scalarNode('name')->defaultNull()->end()
-            ->scalarNode('homepage')->defaultValue('')->end()
-            ->scalarNode('base_path')->defaultValue('')->end()
-            ->booleanNode('archive')->defaultFalse()->end()
-            ->scalarNode('contact_email')->defaultValue('')->end()
-            ->scalarNode('output_dir')->defaultValue('%app.root_dir%/web')->end()
-            ->arrayNode('resque')
-            ->addDefaultsIfNotSet()
-            ->children()
-            ->scalarNode('host')->defaultValue('localhost')->end()
-            ->scalarNode('port')->defaultValue('6379')->end()
-            ->scalarNode('database')->defaultNull()->end()
-            ->end()
-            ->end()
-            ->end();
+                ->scalarNode('site_name')->defaultValue('Private Composer Repository')->end()
+                ->scalarNode('name')->defaultNull()->end()
+                ->scalarNode('homepage')->defaultValue('')->end()
+                ->scalarNode('base_path')->defaultValue('')->end()
+                ->scalarNode('archive')->defaultValue(false)->end()
+                ->scalarNode('contact_email')->defaultValue('')->end()
+                ->scalarNode('secure_satis')->defaultFalse()->end()
+                ->scalarNode('output_dir')->defaultValue('%app.root_dir%/satis')->end()
+                ->arrayNode('resque')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('host')->defaultValue('localhost')->end()
+                        ->scalarNode('port')->defaultValue('6379')->end()
+                        ->scalarNode('database')->defaultNull()->end()
+                    ->end()
+                ->end();
 
         return $treeBuilder;
     }

--- a/src/Plugin/RouterPluginInterface.php
+++ b/src/Plugin/RouterPluginInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright (c) Terramar Labs
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ */
+
+namespace Terramar\Packages\Plugin;
+
+use Terramar\Packages\Router\RouteCollector;
+
+/**
+ * RouterPluginInterface defines the implementation of a plugin that also registers
+ * routes with the RouteCollector.
+ *
+ * @see http://docs.terramarlabs.com/packages/3.2/plugins/creating-a-plugin
+ */
+interface RouterPluginInterface extends PluginInterface
+{
+    /**
+     * Configure the given RouteCollector.
+     *
+     * This method allows a plugin to register additional HTTP routes with the
+     * RouteCollector.
+     *
+     * @param RouteCollector $collector
+     * @return void
+     */
+    public function collect(RouteCollector $collector);
+}

--- a/src/Plugin/Satis/FrontendController.php
+++ b/src/Plugin/Satis/FrontendController.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * Copyright (c) Terramar Labs
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ */
+
+namespace Terramar\Packages\Plugin\Satis;
+
+use Nice\Security\AuthenticatorInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class FrontendController
+{
+    /**
+     * @var bool If true, require HTTP Basic authentication
+     */
+    private $secure = true;
+    /**
+     * @var AuthenticatorInterface
+     */
+    private $authenticator;
+    /**
+     * @var string
+     */
+    private $outputDir;
+    /**
+     * @var string
+     */
+    private $basePath;
+
+    /**
+     * Constructor
+     *
+     * @param array $config
+     * @param AuthenticatorInterface $authenticator
+     */
+    public function __construct(array $config, AuthenticatorInterface $authenticator)
+    {
+        $this->secure = isset($config['secure_satis']) ? (bool)$config['secure_satis'] : true;
+        $this->outputDir = $config['output_dir'];
+        $this->basePath = $config['base_path'];
+        $this->authenticator = $authenticator;
+    }
+
+    /**
+     * Handles packages.json and include/*.json requests.
+     *
+     * If secure_satis is enabled, HTTP Basic authentication will be required.
+     * The username and password required are those defined in config.yml.
+     *
+     * @param Request $request
+     * @return Response
+     */
+    public function outputAction(Request $request)
+    {
+        if ($this->secure) {
+            $username = $request->getUser();
+            $password = $request->getPassword();
+            if (
+                $this->authenticator->authenticate(new Request(['username' => $username, 'password' => $password])) !== true
+            ) {
+                return new Response('', 401, ['WWW-Authenticate' => 'Basic realm="'.$this->basePath.'"']);
+            }
+        }
+
+        return new Response(
+            file_get_contents($this->outputDir.urldecode($request->getPathInfo())),
+            Response::HTTP_OK,
+            ['Content-type' => 'application/json']);
+    }
+}

--- a/src/Router/RouteCollector.php
+++ b/src/Router/RouteCollector.php
@@ -10,9 +10,24 @@
 namespace Terramar\Packages\Router;
 
 use Nice\Router\RouteCollector as BaseCollector;
+use Terramar\Packages\Plugin\RouterPluginInterface;
 
 class RouteCollector extends BaseCollector
 {
+    /**
+     * @var RouterPluginInterface[]
+     */
+    private $plugins = [];
+
+    /**
+     * Register a router plugin with the collector.
+     *
+     * @param RouterPluginInterface $plugin
+     */
+    public function registerPlugin(RouterPluginInterface $plugin) {
+        $this->plugins[$plugin->getName()] = $plugin;
+    }
+
     /**
      * Perform any collection.
      */
@@ -47,5 +62,9 @@ class RouteCollector extends BaseCollector
             'Terramar\Packages\Controller\RemoteController::updateAction', ['POST']);
         $this->map('/manage/remote/{id}/sync', 'manage_remote_sync',
             'Terramar\Packages\Controller\RemoteController::syncAction');
+
+        foreach ($this->plugins as $plugin) {
+            $plugin->collect($this);
+        }
     }
 }


### PR DESCRIPTION
Setting `secure_satis` to true in config.yml will then require that users attempting to access packages.json or include/*.json to provide HTTP Basic credentials. The username and password required is the one defined in config.yml.

Basic auth works well with Composer, you get a nice Authentication required prompt with this enabled.

This feature would supplement #64 nicely, though I admit I didn't look at that PR before I wrote this-- I am betting I duplicated some work. This also fixes #65

This also adds a new way for Plugins to register arbitrary routes (not just plugin actions) with the application's RouteCollector. I added a new interface `Terramar\Packages\Plugin\RouterPluginInterface` that extends the existing `PluginInterface` to ensure no BC breaks occur.

I am not sure whether the `secure_satis` option should default to true. I'd like it to, but to me that breaks BC. Any thoughts?

Advice and suggestions very much appreciated :)

