### PR TITLE
GitLab API V4 support for composer files fetching

### DIFF
--- a/lib/Composer/Repository/Vcs/GitLabDriver.php
+++ b/lib/Composer/Repository/Vcs/GitLabDriver.php
@@ -119,8 +119,8 @@ class GitLabDriver extends VcsDriver
             }
         }
 
-        $resource = $this->getApiUrl().'/repository/blobs/'.$identifier.'?filepath=' . $file;
-
+        $resource = $this->getApiUrl() . '/repository/files/' . $file . '/raw?ref=' . $identifier;
+        
         try {
             $content = $this->getContents($resource);
         } catch (TransportException $e) {


### PR DESCRIPTION
Based on the GitLab's API migration guide from V3 to V4, the blobs api is deprecated and moved to "files"

```
Moved GET /projects/:id/repository/commits/:sha/blob?file_path=:file_path and GET /projects/:id/repository/blobs/:sha?file_path=:file_path to GET /projects/:id/repository/files/:file_path/raw?ref=:sha
```