### PR TITLE
Allow http proxy to work though resque

### DIFF
--- a/src/Console/Command/Worker/StartCommand.php
+++ b/src/Console/Command/Worker/StartCommand.php
@@ -48,6 +48,12 @@ class StartCommand extends ContainerAwareCommand
         $env['REDIS_BACKEND'] = $resqueConfig['backend'];
         $env['REDIS_BACKEND_DB'] = $resqueConfig['database'];
 
+        foreach(['HTTPS_PROXY', 'HTTP_PROXY'] as $key) {
+            if($value = getenv($key)) {
+                $env[$key] = $value;
+            }
+        }
+
         $opt = '';
         if (0 !== $m = (int)$input->getOption('memory-limit')) {
             $opt = sprintf('-d memory_limit=%dM', $m);


### PR DESCRIPTION
This change will allow the resque:worker:start to be run on environments that require requests to go through proxies. This is currently not possible because proc_open does not pass default environment variables to it's proccesses.