### PR TITLE
Fix Notice: Undefined index: argv

### DIFF
--- a/src/Plugin/Satis/InventoryController.php
+++ b/src/Plugin/Satis/InventoryController.php
@@ -88,7 +88,7 @@ class InventoryController extends ContainerAwareController
     {
         $configuration = $this->container->getParameter('packages.configuration');
 
-        $io = new ConsoleIO(new ArgvInput(), new ConsoleOutput(), new HelperSet([]));
+        $io = new ConsoleIO(new ArgvInput([]), new ConsoleOutput(), new HelperSet([]));
         $config = new Config();
         $config->merge([
             'config' => [


### PR DESCRIPTION
If I open /packages I get following Notice:
```
Notice: Undefined index: argv in /var/www/packages/vendor/symfony/console/Input/ArgvInput.php on line 53
```
As a result, the page can not be displayed at all:
```
Warning: array_shift() expects parameter 1 to be array, null given in /var/www/packages/vendor/symfony/console/Input/ArgvInput.php on line 57
```
```
Fatal error: Uncaught RuntimeException: Failed to start the session because headers have already been sent by "/var/www/packages/vendor/symfony/console/Input/ArgvInput.php" at line 57. in /var/www/packages/views/Default/base.html.twig on line 27
```
```
Twig_Error_Runtime: An exception has been thrown during the rendering of a template ("Failed to start the session because headers have already been sent by "/var/www/packages/vendor/symfony/console/Input/ArgvInput.php" at line 57."). in /var/www/packages/views/Default/base.html.twig on line 27
```