### PR TITLE
save allowedPaths on remote creation

### DIFF
--- a/src/Plugin/GitLab/Controller.php
+++ b/src/Plugin/GitLab/Controller.php
@@ -34,6 +34,7 @@ class Controller
         $config->setToken($request->get('gitlab_token'));
         $config->setUrl($request->get('gitlab_url'));
         $config->setEnabled($remote->isEnabled());
+        $config->setAllowedPaths($request->get('gitlab_allowedPaths'));
 
         $entityManager->persist($config);
 


### PR DESCRIPTION
This fixes a bug that allowedPaths are not saved upon creating a new gitlab remote.