### PR TITLE
use fullpath to match allowed paths

### DIFF
--- a/src/Plugin/GitLab/SyncAdapter.php
+++ b/src/Plugin/GitLab/SyncAdapter.php
@@ -79,7 +79,7 @@ class SyncAdapter implements SyncAdapterInterface
 
         $packages = [];
         foreach ($projects as $project) {
-            if (!empty($allowedPathes) && !\in_array($project['namespace']['path'], $allowedPathes, true)) {
+            if (!empty($allowedPathes) && !\in_array($project['namespace']['full_path'], $allowedPathes, true)) {
                 continue;
             }
             if ( ! $this->packageExists($existingPackages, $project['id'])) {


### PR DESCRIPTION
the path variable only contains the deepest nested namespace. This can lead to awkward situations where including one path, could possibly allow another path with the same name in a different namespace. 

E.g. including `foo` would include both `foo`, `bar/foo` and `baz/foo`. There is no way to distinguish between them all.  

Using the full path allows to distinguish between them, so I think this is more functional. However, it does change behaviour a bit, as you now have to specify the full path for all namespaces you want to include. 

This might mean existing installs need to edit their configuration if this PR is to be merged. I'm open to discussion if this is acceptable, or how best to add a configuration option for this.