### PR TITLE
also disable packages if api throws an error

### DIFF
--- a/src/Plugin/GitLab/SyncAdapter.php
+++ b/src/Plugin/GitLab/SyncAdapter.php
@@ -166,11 +166,13 @@ class SyncAdapter implements SyncAdapterInterface
                 }
             } catch (\Exception $e) {
 	            // TODO: Log the exception
-	            $package->setHookExternalId('');
-	            $config->setEnabled(false);
 
 	            return false;
-	        }
+	    } finally {
+	            $package->setHookExternalId('');
+	            $config->setEnabled(false);
+	    	
+	    }
         }
 
         return true;


### PR DESCRIPTION
otherwise it is not possible to re-enable hooks again after a failed disable hook